### PR TITLE
Update LAB[MB-800]_M05_Lab01_Process_Purchases.md

### DIFF
--- a/Instructions/Labs/LAB[MB-800]_M05_Lab01_Process_Purchases.md
+++ b/Instructions/Labs/LAB[MB-800]_M05_Lab01_Process_Purchases.md
@@ -299,7 +299,7 @@ You need to process the invoice.
 
     2.  On the **General** FastTab, fill in the following fields:
 
-        1.  In the **Vendor Name** field, enter ‘V9002’.
+        1.  In the **Vendor Name** field, enter ‘V9007’.
 
         2.  In the **Posting Date** field, enter 1/31/2021.
 


### PR DESCRIPTION
Fixing a typo OakVille is V9007 not V9002

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:
I think there is a typo on this lab . 