### PR TITLE
Backfill missing lab metadata for Instructions/Labs/01-1-Set-up-envir…

### DIFF
--- a/Instructions/Labs/Lab00_Lab_Setup.md
+++ b/Instructions/Labs/Lab00_Lab_Setup.md
@@ -2,6 +2,10 @@
 lab:
     title: 'Lab 0: Validate lab environment'
     module: 'Learning Path 0: Course introduction'
+    description: This appendix contains step-by-step instructions to provision and configure a Dynamics 365 Business Central environment, including prerequisites.
+    duration: 10 minutes
+    level: 200
+    islab: true
 ---
 
 Module 0: Course introduction


### PR DESCRIPTION
Fix #228 

## Summary

This pull request backfills missing **lab metadata** for **Lab 0 – Set up environment** to ensure the lab complies with Microsoft Learn requirements. Adding the required metadata improves consistency across labs and enables correct rendering, validation, and reporting in the learning platform.

---

## Changes

- Added missing lab metadata fields, including:
  - `description`
  - `duration`
  - `level`
  - `isLab`
- Ensured the lab front matter follows the standard Microsoft Learn lab metadata format.


## File changed

`Instructions/Labs/Lab00_Lab_Setup.md`